### PR TITLE
fix: remove not required 3d-secure auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.2.28",
+	"version": "1.2.29",
 	"name": "stripecord",
 	"author": "Digital39999",
 	"scripts": {

--- a/src/core/stripe.ts
+++ b/src/core/stripe.ts
@@ -1417,7 +1417,7 @@ export class StripeSubscriptions {
 					},
 					payment_method_options: {
 						card: {
-							request_three_d_secure: 'any',
+							request_three_d_secure: 'automatic',
 						},
 					},
 				});


### PR DESCRIPTION
fixes issues with banks expecting a 3ds auth flow down the line and soft rejecting payments.

https://docs.stripe.com/payments/3d-secure/authentication-flow#manual-three-ds